### PR TITLE
Fix Contextmenu Position

### DIFF
--- a/frontend/src/Pages/List.vue
+++ b/frontend/src/Pages/List.vue
@@ -40,8 +40,8 @@ function contextmenuShow(event: MouseEvent, entry: Entry) {
   contextmenuVisible.value = true;
   contextmenuTarget.value = entry;
   entry._dirty = true;
-  contextmenuX.value = event.clientX;
-  contextmenuY.value = event.clientY;
+  contextmenuX.value = event.pageX;
+  contextmenuY.value = event.pageY;
   document.addEventListener("click", contextmenuHandleOutsideClick);
 }
 


### PR DESCRIPTION
This commit fixes the contextmenu position for lists, which are longer than the screen.

Closes #30