### PR TITLE
Connect EntryItem.vue as v-model

### DIFF
--- a/frontend/src/Pages/List.vue
+++ b/frontend/src/Pages/List.vue
@@ -7,6 +7,7 @@ import {
   apiCreateEntry,
   apiGetTypes,
   apiDeleteEntry,
+  apiUpdateEntry,
 } from "@/api/api.ts";
 import { type Entry, type Type, type ContextmenuAction } from "@/types.ts";
 import DefaultLayout from "@/Layouts/DefaultLayout.vue";
@@ -172,6 +173,19 @@ async function createEntry() {
   searchInput.value = "";
 }
 
+async function updateEntry(entry: Entry) {
+  try {
+    await apiUpdateEntry(entry);
+  } catch (error) {
+    showError("Unable to update entry", error);
+    return;
+  }
+}
+
+async function changingEntry(value: boolean, entry: Entry) {
+  entry._dirty = value;
+}
+
 onMounted(() => {
   getTypes();
   getEntries();
@@ -199,22 +213,26 @@ onMounted(() => {
     <template v-slot:main>
       <ul>
         <EntryItem
-          v-for="entry in activeSortedNotBoughtEntries"
+          v-for="(entry, i) in activeSortedNotBoughtEntries"
           :key="entry.ID"
-          :entry="entry"
+          v-model="activeSortedNotBoughtEntries[i]"
           :types="types"
           @contextmenu="contextmenuShow($event, entry)"
+          @update="updateEntry(entry)"
+          @changing="changingEntry($event, entry)"
         >
         </EntryItem>
       </ul>
       <hr v-if="activeBoughtEntries.length > 0" />
       <ul>
         <EntryItem
-          v-for="entry in activeBoughtEntries"
+          v-for="(entry, i) in activeBoughtEntries"
           :key="entry.ID"
-          :entry="entry"
+          v-model="activeBoughtEntries[i]"
           :types="types"
           @contextmenu="contextmenuShow($event, entry)"
+          @update="updateEntry(entry)"
+          @changing="changingEntry($event, entry)"
         >
         </EntryItem>
       </ul>


### PR DESCRIPTION
Currently EntryItem.vue directly changes values of it's props, which is not very Vue-ish and only possible because it's an object and no primitive variable. This patch tries to make the code more as intended by using `defineModel` and `v-model` logic instead.