### PR TITLE
Show Types as Colors and in Separators

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,0 +1,3 @@
+Delete Searchbar on change
+Kategorien als Farben
+Kategorien müssen irgendwie angezeigt werden

--- a/api/v1/server/entry.go
+++ b/api/v1/server/entry.go
@@ -68,6 +68,24 @@ func (s server) entryCreate() echo.HandlerFunc {
 	}
 }
 
+func (s server) entryGet() echo.HandlerFunc {
+	type input struct {
+		ID uuid.UUID `param:"ID"`
+	}
+	return func(c echo.Context) error {
+		var i input
+		if err := c.Bind(&i); err != nil {
+			return echo.ErrBadRequest.SetInternal(err)
+		}
+
+		var e database.Entry
+		if err := s.db.First(&e, i.ID).Error; err != nil {
+			return echo.NotFoundHandler(c)
+		}
+		return c.JSON(http.StatusOK, e)
+	}
+}
+
 func (s server) entryUpdate() echo.HandlerFunc {
 	type input struct {
 		ID     uuid.UUID `param:"ID"`

--- a/api/v1/server/server.go
+++ b/api/v1/server/server.go
@@ -25,6 +25,7 @@ func (s server) SetupRoutes(g *echo.Group) {
 	// entries
 	g.GET("/entries", s.entryList())
 	g.POST("/entries", s.entryCreate())
+	g.GET("/entries/:id", s.entryGet())
 	g.PUT("/entries/:id", s.entryUpdate())
 	g.DELETE("/entries/:id", s.entryDelete())
 	g.GET("/entries/events", s.entryGetEvents())

--- a/database/init.go
+++ b/database/init.go
@@ -45,18 +45,18 @@ func Init(dsn string) (*gorm.DB, error) {
 
 	// types to database
 	types := []Type{
-		{Name: "fruit", Icon: "🍎"},
-		{Name: "vegetable", Icon: "🥦"},
-		{Name: "drink", Icon: "🍹"},
-		{Name: "meat", Icon: "🍖"},
-		{Name: "snack", Icon: "🍿"},
-		{Name: "dairy", Icon: "🧀"},
-		{Name: "bread", Icon: "🥖"},
-		{Name: "condiment", Icon: "🧂"},
-		{Name: "frozen", Icon: "❄️"},
-		{Name: "canned", Icon: "🥫"},
-		{Name: "spice", Icon: "🌶️"},
-		{Name: "unknown", Icon: "🤷‍♀️"},
+		{Name: "fruit", Icon: "🍎", Color: "crimson"},
+		{Name: "vegetable", Icon: "🥦", Color: "green"},
+		{Name: "drink", Icon: "🍹", Color: "orange"},
+		{Name: "meat", Icon: "🍖", Color: "red"},
+		{Name: "snack", Icon: "🍿", Color: "yellow"},
+		{Name: "dairy", Icon: "🧀", Color: "gold"},
+		{Name: "bread", Icon: "🥖", Color: "saddlebrown"},
+		{Name: "condiment", Icon: "🧂", Color: "gray"},
+		{Name: "frozen", Icon: "❄️", Color: "lightblue"},
+		{Name: "canned", Icon: "🥫", Color: "silver"},
+		{Name: "spice", Icon: "🌶️", Color: "darkred"},
+		{Name: "unknown", Icon: "🤷‍♀️", Color: "black"},
 	}
 	for _, t := range types {
 		if err := db.Save(&t).Error; err != nil {

--- a/database/models.go
+++ b/database/models.go
@@ -63,6 +63,7 @@ func (e *Entry) BeforeCreate(tx *gorm.DB) error {
 }
 
 type Type struct {
-	Name string `gorm:"primaryKey"`
-	Icon string
+	Name  string `gorm:"primaryKey"`
+	Icon  string
+	Color string
 }

--- a/frontend/src/Components/EntryItem.vue
+++ b/frontend/src/Components/EntryItem.vue
@@ -1,11 +1,7 @@
 <script setup lang="ts">
-import { type Entry, type Type } from "@/types.ts";
+import { type Entry } from "@/types.ts";
 
 import Button from "@/Components/Button.vue";
-
-defineProps<{
-  types: Type[];
-}>();
 
 const emit = defineEmits<{
   (e: "update"): void;
@@ -20,27 +16,20 @@ function onClick() {
 </script>
 
 <template>
-  <li>
-    <div class="entryAttributes">
-      <select v-model="entry.TypeID" @change="$emit('update')">
-        <option v-for="type in types" :key="type.Name" :value="type.Name">
-          {{ type.Icon }}
-        </option>
-      </select>
-      <div>{{ entry.Name }}</div>
+  <div class="entry">
+    <div class="name">
+      {{ entry.Name }}
     </div>
     <div class="entryAttributes">
       <input v-model="entry.Number" type="text" @blur="$emit('update')" />
       <Button @click="onClick">{{ entry.Bought ? "+" : "✓" }}</Button>
     </div>
-  </li>
+  </div>
 </template>
 
 <style scoped>
-li {
+.entry {
   padding: 0.1em 0em;
-  margin: 0.2em 0em;
-  border-radius: var(--border-radius);
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -48,9 +37,13 @@ li {
 }
 
 @media (hover: hover) and (pointer: fine) {
-  li:hover {
+  .entry:hover {
     background: var(--color-surface-hover);
   }
+}
+
+.name {
+  padding-left: 0.5em;
 }
 
 .entryAttributes {
@@ -59,17 +52,9 @@ li {
   gap: 0.5em;
 }
 
-li input {
+input {
   width: 6em;
   border: 0.1em solid var(--color-accent);
   text-align: right;
-}
-
-select {
-  width: 3em;
-  height: 2.5em;
-  background: var(--color-surface);
-  border: 0.1em solid var(--color-border);
-  border-radius: var(--border-radius);
 }
 </style>

--- a/frontend/src/Pages/TypeSelector.vue
+++ b/frontend/src/Pages/TypeSelector.vue
@@ -1,0 +1,87 @@
+<script setup lang="ts">
+import { onMounted, ref } from "vue";
+import { useRoute } from "vue-router";
+
+import { apiGetEntry, apiGetTypes, apiUpdateEntry } from "@/api/api";
+import type { Entry, Type } from "@/types";
+import { router } from "@/router.ts";
+import { useNotificationManager } from "@/composables/useNotificationManager";
+
+import DefaultLayout from "@/Layouts/DefaultLayout.vue";
+
+const { show } = useNotificationManager();
+const route = useRoute();
+const entryID = route.params.id as string;
+
+const entry = ref<Entry>();
+const types = ref<Type[]>();
+
+async function update(typeID: string) {
+  if (entry.value === undefined) {
+    return;
+  }
+  entry.value.TypeID = typeID;
+  try {
+    await apiUpdateEntry(entry.value);
+  } catch (error) {
+    show("error", "Unable to update entry", { logMessage: error });
+    return;
+  }
+  router.back();
+}
+onMounted(async () => {
+  try {
+    entry.value = await apiGetEntry(entryID);
+    types.value = await apiGetTypes();
+  } catch (error) {
+    show("error", "unable to connect to server", { logMessage: error });
+  }
+});
+</script>
+<template>
+  <DefaultLayout>
+    <template v-slot:header>
+      <h1>Listinator - Select Type</h1>
+    </template>
+    <template v-slot:main>
+      <ul>
+        <li
+          v-for="type in types"
+          @click="update(type.Name)"
+          :style="{ borderLeft: `0.3em solid ${type.Color}` }"
+        >
+          <div>
+            {{ type.Icon }}
+            {{ type.Name }}
+          </div>
+        </li>
+      </ul>
+    </template>
+  </DefaultLayout>
+</template>
+
+<style scoped>
+ul {
+  /* no bullet points */
+  list-style: none;
+  padding: 0em;
+  margin: 0em;
+}
+
+div {
+  min-height: 2.5em;
+  padding: 0.2em;
+  margin: 0.5em 0em;
+  border-radius: var(--border-radius);
+  display: flex;
+  cursor: pointer;
+  align-items: center;
+  background: var(--color-surface);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  div:hover {
+    background: var(--color-surface-hover);
+  }
+}
+</style>

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -41,6 +41,11 @@ export async function apiCreateEntry(
   return json as Entry;
 }
 
+export async function apiGetEntry(entryID: string): Promise<Entry> {
+  const json = await apiFetchJSON(`/api/v1/entries/${entryID}`);
+  return json as Entry;
+}
+
 export async function apiUpdateEntry(entry: Entry): Promise<Entry> {
   const json = await apiFetchJSON(`/api/v1/entries/${entry.ID}`, {
     method: "PUT",

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -3,10 +3,12 @@ import { createWebHashHistory, createRouter } from "vue-router";
 import Home from "./Pages/Home.vue";
 import List from "./Pages/List.vue";
 import Login from "./Pages/Login.vue";
+import TypeSelector from "./Pages/TypeSelector.vue";
 
 const routes = [
   { path: "/", component: Home, name: "home" },
   { path: "/list/:id", component: List, name: "list" },
+  { path: "/entry/:id/type", component: TypeSelector, name: "typeSelector" },
   { path: "/login", component: Login, name: "login" },
 ];
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5,6 +5,7 @@ export interface List {
 export interface Type {
   Name: string;
   Icon: string;
+  Color: string;
 }
 
 export interface Entry {


### PR DESCRIPTION
Types in the Lists are not shows as colors and in separators. This way the UI looks a little bit cleaner.

To change a Type, you now have to open the contextmenu and change the type via a new Type Selector Page.

<img width="368" height="888" alt="image" src="https://github.com/user-attachments/assets/60762e8f-ae4a-46a8-a0ce-3cee8811784f" />
<img width="368" height="888" alt="image" src="https://github.com/user-attachments/assets/b4d0c67c-6784-405d-9a11-9300448b1bbd" />
